### PR TITLE
kerf: Extract embedded vmlinux from compressed bzImage in kerf load

### DIFF
--- a/src/kerf/load/main.py
+++ b/src/kerf/load/main.py
@@ -26,6 +26,7 @@ from typing import Optional
 import click
 
 from ..utils import get_instance_id_from_name, get_instance_name_from_id
+from ..vmlinuz import BZIMAGE_HEADER_SIZE, VmlinuzError, is_bzimage, open_kernel_fd
 
 
 # KEXEC flags definitions
@@ -239,6 +240,12 @@ def load(  # pylint: disable=too-many-arguments,too-many-positional-arguments,to
 
     This command loads a kernel image into memory using the kexec_file_load
     syscall. The kernel is loaded in multikernel mode with the specified ID.
+
+    Both an uncompressed ELF vmlinux and a compressed bzImage (vmlinuz) are
+    accepted. For a bzImage, the embedded vmlinux is extracted in userspace
+    before loading, since the kernel side only accepts ELF images. Note that
+    an extracted vmlinux carries no signature, so this will not work on
+    hosts enforcing kexec signature verification (Secure Boot lockdown).
 
     When --image or --rootfs-dir is provided, a daxfs image is created and the
     kernel boots directly into daxfs as root filesystem (no initrd needed if
@@ -500,9 +507,17 @@ def load(  # pylint: disable=too-many-arguments,too-many-positional-arguments,to
             click.echo(f"Command line: {cmdline_str if cmdline_str else '(empty)'}")
             click.echo(f"Flags: 0x{flags:x}")
 
-        # Open kernel file
+        # Open kernel file, extracting the embedded vmlinux if it is a
+        # bzImage, since the kexec ELF loader only accepts vmlinux
         try:
-            kernel_fd = os.open(str(kernel_path), os.O_RDONLY)
+            with open(kernel_path, "rb") as f:
+                kernel_is_bzimage = is_bzimage(f.read(BZIMAGE_HEADER_SIZE))
+            if kernel_is_bzimage and verbose:
+                click.echo("bzImage detected, extracting embedded vmlinux")
+            kernel_fd = open_kernel_fd(kernel_path)
+        except VmlinuzError as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(3)
         except OSError as e:
             click.echo(f"Error: Failed to open kernel image: {e}", err=True)
             sys.exit(3)

--- a/src/kerf/vmlinuz.py
+++ b/src/kerf/vmlinuz.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Multikernel Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+bzImage (vmlinuz) detection and embedded vmlinux extraction.
+
+On x86 the bzImage payload is the original ELF vmlinux, stripped but
+otherwise intact (arch/x86/boot/compressed/Makefile uses plain objcopy,
+not -O binary), so decompressing it yields an image the kexec ELF
+loader accepts directly. This is the same trick the kernel's own
+scripts/extract-vmlinux relies on.
+"""
+
+import bz2
+import lzma
+import os
+import struct
+import subprocess
+import zlib
+
+from .exceptions import KerfError
+
+
+class VmlinuzError(KerfError):
+    """Raised when a bzImage cannot be parsed or its payload extracted."""
+
+
+ELF_MAGIC = b"\x7fELF"
+
+# x86 boot protocol setup header fields (Documentation/arch/x86/boot.rst)
+BZIMAGE_SETUP_SECTS = 0x1F1
+BZIMAGE_MAGIC = 0x202
+BZIMAGE_VERSION = 0x206
+BZIMAGE_PAYLOAD_OFFSET = 0x248
+BZIMAGE_PAYLOAD_LENGTH = 0x24C
+BZIMAGE_HEADER_SIZE = 0x250
+
+
+def is_bzimage(data: bytes) -> bool:
+    """Check for the x86 boot protocol magic in a kernel image."""
+    return data[BZIMAGE_MAGIC:BZIMAGE_MAGIC + 4] == b"HdrS"
+
+
+def _gunzip(payload: bytes) -> bytes:
+    return zlib.decompressobj(zlib.MAX_WBITS | 16).decompress(payload)
+
+
+def _unxz(payload: bytes) -> bytes:
+    return lzma.LZMADecompressor(format=lzma.FORMAT_XZ).decompress(payload)
+
+
+def _unlzma(payload: bytes) -> bytes:
+    return lzma.LZMADecompressor(format=lzma.FORMAT_ALONE).decompress(payload)
+
+
+def _bunzip2(payload: bytes) -> bytes:
+    return bz2.BZ2Decompressor().decompress(payload)
+
+
+def _decompress_cli(argv: list, payload: bytes) -> bytes:
+    try:
+        proc = subprocess.run(
+            argv, input=payload, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, check=False,
+        )
+    except FileNotFoundError:
+        raise VmlinuzError(
+            f"'{argv[0]}' binary not found, required to decompress this kernel"
+        ) from None
+    # The CLI tools complain about data trailing the compressed stream
+    # (relocations, appended size), but still emit the decoded output
+    if not proc.stdout:
+        raise VmlinuzError(f"{argv[0]} failed to decompress kernel payload")
+    return proc.stdout
+
+
+def _unzstd(payload: bytes) -> bytes:
+    try:
+        import zstandard
+    except ImportError:
+        return _decompress_cli(["zstd", "-d", "-c"], payload)
+    try:
+        return zstandard.ZstdDecompressor().decompressobj().decompress(payload)
+    except zstandard.ZstdError as e:
+        raise VmlinuzError(f"kernel payload decompression failed: {e}") from e
+
+
+def _unlz4(payload: bytes) -> bytes:
+    return _decompress_cli(["lz4", "-d", "-c"], payload)
+
+
+_DECOMPRESSORS = [
+    (b"\x1f\x8b", _gunzip),
+    (b"\xfd7zXZ\x00", _unxz),
+    (b"BZh", _bunzip2),
+    (b"\x28\xb5\x2f\xfd", _unzstd),
+    (b"\x02\x21\x4c\x18", _unlz4),
+    (b"\x04\x22\x4d\x18", _unlz4),
+    (b"\x5d\x00", _unlzma),
+]
+
+
+def _decompress(payload: bytes) -> bytes:
+    for magic, decompress in _DECOMPRESSORS:
+        if payload.startswith(magic):
+            try:
+                return decompress(payload)
+            except (OSError, EOFError, zlib.error, lzma.LZMAError) as e:
+                raise VmlinuzError(f"kernel payload decompression failed: {e}") from e
+    if payload.startswith(b"\x89LZO"):
+        raise VmlinuzError("LZO kernel compression is not supported")
+    raise VmlinuzError(
+        f"unknown kernel compression format (payload magic {payload[:4].hex()})"
+    )
+
+
+def _elf_size(data: bytes) -> int:
+    """Size of the ELF image, excluding anything appended after it."""
+    if data[4:6] != b"\x02\x01":
+        raise VmlinuzError("embedded vmlinux is not a little-endian ELF64 image")
+    e_phoff, e_shoff = struct.unpack_from("<QQ", data, 32)
+    e_phentsize, e_phnum, e_shentsize, e_shnum = struct.unpack_from("<HHHH", data, 54)
+    end = max(64, e_phoff + e_phentsize * e_phnum, e_shoff + e_shentsize * e_shnum)
+    for i in range(e_phnum):
+        p_offset, _, _, p_filesz = struct.unpack_from(
+            "<QQQQ", data, e_phoff + i * e_phentsize + 8
+        )
+        end = max(end, p_offset + p_filesz)
+    return min(end, len(data))
+
+
+def extract_vmlinux(data: bytes) -> bytes:
+    """Extract the embedded ELF vmlinux from a bzImage."""
+    if not is_bzimage(data):
+        raise VmlinuzError("not a bzImage (missing HdrS boot protocol magic)")
+
+    version = struct.unpack_from("<H", data, BZIMAGE_VERSION)[0]
+    if version < 0x0208:
+        raise VmlinuzError(
+            f"boot protocol {version >> 8}.{version & 0xFF:02d} is too old "
+            "(payload location fields require >= 2.08)"
+        )
+
+    setup_sects = data[BZIMAGE_SETUP_SECTS] or 4
+    payload_offset, payload_length = struct.unpack_from(
+        "<II", data, BZIMAGE_PAYLOAD_OFFSET
+    )
+    start = (setup_sects + 1) * 512 + payload_offset
+    payload = data[start:start + payload_length]
+    if len(payload) < payload_length:
+        raise VmlinuzError("bzImage is truncated (payload extends past end of file)")
+
+    vmlinux = _decompress(payload)
+    if not vmlinux.startswith(ELF_MAGIC):
+        raise VmlinuzError("decompressed payload is not an ELF image")
+
+    # Relocatable kernels have the relocation table appended after the
+    # ELF image; drop it in case the kernel-side loader is strict
+    return vmlinux[:_elf_size(vmlinux)]
+
+
+def open_kernel_fd(path) -> int:
+    """
+    Open a kernel image for kexec_file_load.
+
+    An ELF vmlinux is opened directly. A bzImage is decompressed and the
+    embedded vmlinux is returned as an anonymous in-memory file.
+    """
+    with open(path, "rb") as f:
+        head = f.read(BZIMAGE_HEADER_SIZE)
+        if not is_bzimage(head):
+            return os.open(str(path), os.O_RDONLY)
+        data = head + f.read()
+
+    vmlinux = extract_vmlinux(data)
+    memfd = os.memfd_create("kerf-vmlinux")
+    try:
+        os.write(memfd, vmlinux)
+        os.lseek(memfd, 0, os.SEEK_SET)
+    except OSError:
+        os.close(memfd)
+        raise
+    return memfd

--- a/tests/test_vmlinuz.py
+++ b/tests/test_vmlinuz.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Multikernel Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for bzImage (vmlinuz) detection and vmlinux extraction.
+"""
+
+import gzip
+import lzma
+import os
+import struct
+
+import pytest
+
+from kerf.vmlinuz import VmlinuzError, extract_vmlinux, is_bzimage, open_kernel_fd
+
+
+def make_elf64(body: bytes = b"kernel code segment") -> bytes:
+    """Build a minimal ELF64 image with one program header."""
+    ehdr_size = 64
+    phdr_size = 56
+    p_offset = ehdr_size + phdr_size
+
+    ehdr = struct.pack(
+        "<4sBBBBB7xHHIQQQIHHHHHH",
+        b"\x7fELF",  # magic
+        2,  # ELFCLASS64
+        1,  # ELFDATA2LSB
+        1,  # EV_CURRENT
+        0,  # ELFOSABI_NONE
+        0,  # ABI version
+        2,  # ET_EXEC
+        0x3E,  # EM_X86_64
+        1,  # e_version
+        0xFFFFFFFF81000000,  # e_entry
+        ehdr_size,  # e_phoff
+        0,  # e_shoff
+        0,  # e_flags
+        ehdr_size,  # e_ehsize
+        phdr_size,  # e_phentsize
+        1,  # e_phnum
+        0,  # e_shentsize
+        0,  # e_shnum
+        0,  # e_shstrndx
+    )
+    phdr = struct.pack(
+        "<IIQQQQQQ",
+        1,  # PT_LOAD
+        5,  # PF_R | PF_X
+        p_offset,  # p_offset
+        0xFFFFFFFF81000000,  # p_vaddr
+        0x1000000,  # p_paddr
+        len(body),  # p_filesz
+        len(body),  # p_memsz
+        0x200000,  # p_align
+    )
+    return ehdr + phdr + body
+
+
+def make_bzimage(payload: bytes, setup_sects: int = 4, version: int = 0x020F) -> bytes:
+    """Build a minimal bzImage wrapping the given compressed payload."""
+    header = bytearray(512 * ((setup_sects or 4) + 1))
+    header[0x1F1] = setup_sects
+    header[0x202:0x206] = b"HdrS"
+    struct.pack_into("<H", header, 0x206, version)
+    struct.pack_into("<I", header, 0x248, 0)  # payload_offset
+    struct.pack_into("<I", header, 0x24C, len(payload))  # payload_length
+    return bytes(header) + payload
+
+
+class TestIsBzimage:
+    def test_detects_bzimage_magic(self):
+        data = make_bzimage(b"\x00" * 16)
+        assert is_bzimage(data) is True
+
+    def test_rejects_elf(self):
+        assert is_bzimage(make_elf64()) is False
+
+    def test_rejects_short_file(self):
+        assert is_bzimage(b"\x7fELF") is False
+
+
+class TestExtractVmlinux:
+    def test_extracts_gzip_payload(self):
+        elf = make_elf64()
+        data = make_bzimage(gzip.compress(elf))
+        assert extract_vmlinux(data) == elf
+
+    def test_extracts_xz_payload(self):
+        elf = make_elf64()
+        # Kernel build appends the uncompressed size after the xz stream
+        payload = lzma.compress(elf, format=lzma.FORMAT_XZ) + struct.pack("<I", len(elf))
+        data = make_bzimage(payload)
+        assert extract_vmlinux(data) == elf
+
+    def test_extracts_lzma_payload(self):
+        elf = make_elf64()
+        payload = lzma.compress(elf, format=lzma.FORMAT_ALONE) + struct.pack("<I", len(elf))
+        data = make_bzimage(payload)
+        assert extract_vmlinux(data) == elf
+
+    def test_extracts_bzip2_payload(self):
+        import bz2
+
+        elf = make_elf64()
+        payload = bz2.compress(elf) + struct.pack("<I", len(elf))
+        data = make_bzimage(payload)
+        assert extract_vmlinux(data) == elf
+
+    def test_extracts_zstd_payload(self):
+        zstandard = pytest.importorskip("zstandard")
+        elf = make_elf64()
+        payload = zstandard.ZstdCompressor().compress(elf) + struct.pack("<I", len(elf))
+        data = make_bzimage(payload)
+        assert extract_vmlinux(data) == elf
+
+    def test_truncates_trailing_relocations(self):
+        elf = make_elf64()
+        data = make_bzimage(gzip.compress(elf + b"RELOCATION-TABLE" * 8))
+        assert extract_vmlinux(data) == elf
+
+    def test_setup_sects_zero_defaults_to_four(self):
+        elf = make_elf64()
+        data = make_bzimage(gzip.compress(elf), setup_sects=0)
+        # setup_sects=0 means 4 per the boot protocol, so the header
+        # area is identical to the setup_sects=4 layout
+        assert extract_vmlinux(data) == elf
+
+    def test_rejects_unknown_compression(self):
+        data = make_bzimage(b"\x00\x01\x02\x03 not compressed data")
+        with pytest.raises(VmlinuzError, match="compression"):
+            extract_vmlinux(data)
+
+    def test_rejects_old_boot_protocol(self):
+        data = make_bzimage(gzip.compress(make_elf64()), version=0x0207)
+        with pytest.raises(VmlinuzError, match="boot protocol"):
+            extract_vmlinux(data)
+
+    def test_rejects_non_elf_payload(self):
+        data = make_bzimage(gzip.compress(b"this is not an ELF image"))
+        with pytest.raises(VmlinuzError, match="ELF"):
+            extract_vmlinux(data)
+
+    def test_rejects_non_bzimage(self):
+        with pytest.raises(VmlinuzError, match="bzImage"):
+            extract_vmlinux(make_elf64())
+
+
+class TestOpenKernelFd:
+    def test_elf_file_passthrough(self, tmp_path):
+        elf = make_elf64()
+        path = tmp_path / "vmlinux"
+        path.write_bytes(elf)
+
+        fd = open_kernel_fd(path)
+        try:
+            assert os.read(fd, len(elf) + 1) == elf
+        finally:
+            os.close(fd)
+
+    def test_bzimage_is_extracted_to_memfd(self, tmp_path):
+        elf = make_elf64()
+        path = tmp_path / "vmlinuz"
+        path.write_bytes(make_bzimage(gzip.compress(elf)))
+
+        fd = open_kernel_fd(path)
+        try:
+            assert os.read(fd, len(elf) + 1) == elf
+        finally:
+            os.close(fd)


### PR DESCRIPTION
## Summary

`kerf load` previously required an uncompressed ELF vmlinux, so a distro `/boot/vmlinuz` could not be passed directly. This PR lifts that restriction entirely in userspace, with no kernel-side changes.

On x86 the bzImage payload is the original vmlinux, stripped but still in ELF form (the same fact the kernel's own `scripts/extract-vmlinux` relies on), so decompressing it yields exactly the image the multikernel kexec ELF loader already accepts.

## Implementation

* New `kerf.vmlinuz` module:
  * Detects a bzImage via the `HdrS` boot protocol magic; plain ELF files pass through unchanged.
  * Locates the compressed stream using the `payload_offset`/`payload_length` setup header fields (boot protocol 2.08+).
  * Detects compression by magic bytes: gzip, xz, lzma, bzip2 via stdlib; zstd via the `zstandard` module with a `zstd` CLI fallback; lz4 via the `lz4` CLI; LZO is rejected with a clear message.
  * Verifies the ELF magic and truncates the relocation table appended after the ELF image on relocatable kernels.
  * Hands the extracted vmlinux to `kexec_file_load` through an anonymous `memfd`, so nothing is written to disk.
* `kerf load` reports the extraction under `--verbose` and maps extraction failures to a clean error with exit code 3.

## Caveat

An extracted vmlinux carries no signature, so this does not work on hosts enforcing kexec signature verification under Secure Boot lockdown. This is documented in the command help.

## Testing

16 new unit tests in `tests/test_vmlinuz.py` build synthetic bzImages around a handcrafted minimal ELF64 and cover every compression format with real compressed streams, trailing relocation truncation, the `setup_sects=0` default, old boot protocol rejection, and error paths. Full suite: 93 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)